### PR TITLE
Add `string_of_error` for block error values

### DIFF
--- a/lib/mirage_block_error.ml
+++ b/lib/mirage_block_error.ml
@@ -22,6 +22,12 @@
    | `Disconnected
  ]
 
+let string_of_error = function
+   | `Unknown x -> Printf.sprintf "Unknown %s" x
+   | `Unimplemented -> "Operation is not implemented"
+   | `Is_read_only -> "Block device is read-only"
+   | `Disconnected -> "Block device is disconnected"
+
 exception Error of error
 
  type 'a result = [

--- a/lib/mirage_block_error.mli
+++ b/lib/mirage_block_error.mli
@@ -23,6 +23,9 @@ type error = [
 ]
 (** The type for IO operation errors. *)
 
+val string_of_error: error -> string
+(** Pretty-print an error value *)
+
 exception Error of error
 (** An error value wrapped up in an exception *)
 


### PR DESCRIPTION
Signed-off-by: David Scott <dave.scott@unikernel.com>