### PR TITLE
Add functor Make_safe_BLOCK

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -13,7 +13,7 @@ Library mirage_block
   Path:               lib
   Findlibname:        mirage-block
   Modules:            Mirage_block_s, Mirage_block_error, Mirage_block_monad, Mirage_block, Mirage_block_copy, Mirage_block_patterns, Mirage_block_compare, Mirage_block_iter
-  BuildDepends:       cstruct, io-page, mirage-types.lwt, lwt
+  BuildDepends:       cstruct, io-page, mirage-types.lwt, lwt, logs
 
 Document mirage_block
   Title:                Mirage block documentation

--- a/lib/mirage_block_log.ml
+++ b/lib/mirage_block_log.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (C) 2015 David Scott <dave.scott@unikernel.com>
+ * Copyright (C) 2016 David Scott <dave.scott@docker.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -15,20 +15,11 @@
  *
  *)
 
-module Error = Mirage_block_error
+let src =
+   let src = Logs.Src.create "mirage-block" ~doc:"Mirage BLOCK interface" in
+   Logs.Src.set_level src (Some Logs.Info);
+   src
 
-let fold_s = Mirage_block_iter.fold_s
+ module Log = (val Logs.src_log src : Logs.LOG)
 
-let fold_mapped_s = Mirage_block_iter.fold_mapped_s
-
-let fold_unmapped_s = Mirage_block_iter.fold_unmapped_s
-
-let compare = Mirage_block_compare.compare
-
-let copy = Mirage_block_copy.copy
-
-let sparse_copy = Mirage_block_copy.sparse_copy
-
-let random = Mirage_block_patterns.random
-
-module Make_safe_BLOCK = Mirage_block_safe.BLOCK
+ include Log

--- a/lib/mirage_block_safe.ml
+++ b/lib/mirage_block_safe.ml
@@ -1,0 +1,67 @@
+(*
+ * Copyright (C) 2015 David Scott <dave.scott@docker.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+open Lwt
+open Mirage_block_log
+
+let fatalf fmt = Printf.ksprintf (fun s ->
+    err (fun f -> f "%s" s);
+    return (`Error (`Unknown s))
+  ) fmt
+
+let check_buffer op sector_size b =
+  let open Mirage_block_monad.Infix in
+  (* Check buffers are whole numbers of sectors *)
+  ( let len = Cstruct.len b in
+    if len mod sector_size <> 0
+    then fatalf "%s: buffer length (%d) is not a multiple of sector_size (%d)" op len sector_size
+    else Lwt.return (`Ok ()) )
+  >>= fun () ->
+  (* TODO: Check buffers are sector-aligned *)
+  Lwt.return (`Ok ())
+
+let rec check_buffers op sector_size = function
+  | [] -> Lwt.return (`Ok ())
+  | b :: bs ->
+    let open Mirage_block_monad.Infix in
+    check_buffer op sector_size b
+    >>= fun () ->
+    check_buffers op sector_size bs
+
+module BLOCK(B: V1_LWT.BLOCK) = struct
+  include B
+
+  let unsafe_read = read
+  let unsafe_write = write
+
+  let read t offset buffers =
+    let open Lwt.Infix in
+    B.get_info t
+    >>= fun info ->
+    let open Mirage_block_monad.Infix in
+    check_buffers "read" info.sector_size buffers
+    >>= fun () ->
+    unsafe_read t offset buffers
+
+  let write t offset buffers =
+    let open Lwt.Infix in
+    B.get_info t
+    >>= fun info ->
+    let open Mirage_block_monad.Infix in
+    check_buffers "write" info.sector_size buffers
+    >>= fun () ->
+    unsafe_write t offset buffers
+end

--- a/opam
+++ b/opam
@@ -24,6 +24,7 @@ depends: [
   "cstruct"
   "mirage-types-lwt"
   "lwt"
+  "logs"
   "ocamlfind" {build}
   "oasis" {build}
   "ounit" {test}


### PR DESCRIPTION
The V1_LWT.BLOCK interface requires certain buffer preconditions are satisfied, including the buffers must be whole numbers of sectors in length. It's easy to forget to do this, with unpredictable results; sometimes it will work on one backend but then fail on another.

The `Make_safe_BLOCK` functor wraps `read` and `write` to check the preconditions and generate useful log and error messages.

Fixes [mirage/mirage#448]