### PR TITLE
resize should return a write_error

### DIFF
--- a/lwt/mirage_block_lwt.mli
+++ b/lwt/mirage_block_lwt.mli
@@ -40,7 +40,7 @@ end
 module type RESIZABLE = sig
   include S
 
-  val resize : t -> int64 -> (unit, error) result io
+  val resize : t -> int64 -> (unit, write_error) result io
   (** [resize t new_size_sectors] attempts to resize the connected device
       to have the given number of sectors. If successful, subsequent calls
       to [get_info] will reflect the new size. *)

--- a/lwt/mirage_block_lwt_s.ml
+++ b/lwt/mirage_block_lwt_s.ml
@@ -29,5 +29,5 @@ end
 
 module type RESIZABLE = sig
   include S
-  val resize : t -> int64 -> (unit, error) result io
+  val resize : t -> int64 -> (unit, write_error) result io
 end


### PR DESCRIPTION
Resize modifies the block device, so should return a write_error.

Signed-off-by: David Scott <dave@recoil.org>