### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-block-lwt.opam
+++ b/mirage-block-lwt.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-block/"
 bug-reports: "https://github.com/mirage/mirage-block/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "cstruct" {>= "2.0.0"}
   "io-page"
   "lwt"

--- a/mirage-block.opam
+++ b/mirage-block.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-block/"
 bug-reports: "https://github.com/mirage/mirage-block/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-device" {>= "1.0.0"}
 ]
 build: [


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.