### PR TITLE
Add pp_info

### DIFF
--- a/src/mirage_block.ml
+++ b/src/mirage_block.ml
@@ -32,6 +32,15 @@ type info = {
   size_sectors: int64; (** Total sectors per device *)
 }
 
+let pp_info ppf { read_write; sector_size; size_sectors } =
+  Format.fprintf ppf
+    "@[<2>{ \
+     @[Mirage_block.read_write =@ %B@];@ \
+     @[sector_size =@ %d@];@ \
+     @[size_sectors =@ %LdL@]@ \
+     }@]"
+    read_write sector_size size_sectors
+
 module type S = sig
   type nonrec error = private [> error ]
   val pp_error: error Fmt.t

--- a/src/mirage_block.mli
+++ b/src/mirage_block.mli
@@ -39,6 +39,8 @@ type info = {
 (** The type for characteristics of the block device. Note some
     devices may be able to make themselves bigger over time. *)
 
+val pp_info : Format.formatter -> info -> unit
+
 (** Operations on sector-addressible block devices, usually used for
     persistent storage. *)
 module type S = sig

--- a/src/mirage_block.mli
+++ b/src/mirage_block.mli
@@ -40,6 +40,7 @@ type info = {
     devices may be able to make themselves bigger over time. *)
 
 val pp_info : Format.formatter -> info -> unit
+(** [pp_info] is the pretty-printer for {info}. *)
 
 (** Operations on sector-addressible block devices, usually used for
     persistent storage. *)


### PR DESCRIPTION
It's the same format as you would get if you had used ppx_deriving.show.

Motivated by this comment in mirage-skeleton:
https://github.com/mirage/mirage-skeleton/blob/f7e437cb19c53c82ff312f88faec51f011635599/device-usage/block/unikernel.ml#L103