### PR TITLE
Add a `READ_ONLY` interface which allows us to manipulate the block device outside  `lwt`

### DIFF
--- a/src/mirage_block.ml
+++ b/src/mirage_block.ml
@@ -53,3 +53,12 @@ module type S = sig
   val write: t -> int64 -> Cstruct.t list ->
     (unit, write_error) result Lwt.t
 end
+
+module type READ_ONLY = sig
+  type nonrec error = private [> error ]
+  val pp_error: error Fmt.t
+  type t
+  val disconnect : t -> unit Lwt.t
+  val get_info : t -> info Lwt.t
+  val read : t -> int64 -> Cstruct.t list -> (unit, error) result
+end

--- a/src/mirage_block.mli
+++ b/src/mirage_block.mli
@@ -101,3 +101,40 @@ module type S = sig
       re-used until the IO operation completes. *)
 
 end
+
+(** Operations on sector-addressible block devices, only for reading. *)
+module type READ_ONLY = sig
+
+  type nonrec error = private [> error ]
+  (** The type for block errors. *)
+
+  val pp_error: error Fmt.t
+  (** [pp_error] is the pretty-printer for errors. *)
+
+  type t
+  (** The type representing the internal state of the block device *)
+
+  val disconnect : t -> unit Lwt.t
+  (** Disconnect from the device. While this might take some time to
+      complete, it can never result in an error. *)
+
+  val get_info : t -> info Lwt.t
+  (** Query the characteristics of a specific block device *)
+
+  val read : t -> int64 -> Cstruct.t list -> (unit, error) result
+  (** [read device sector_start buffers] reads data starting at
+      [sector_start] from the block device into [buffers]. [Ok ()]
+      means the buffers have been filled.  [Error _] indicates an I/O
+      error has happened and some of the buffers may not be filled.
+      Each of elements in the list [buffers] must be a whole number of
+      sectors in length.  The list of buffers can be of any length.  Some
+      implementations may further require that each element in [buffers] is
+      exactly [sector_size] long.
+
+      {b NOTE}: due to the read-only view, we can read outside the scheduler
+      ([lwt]) because such view disallow write operations. By this way, the call
+      to {!val:read} is morally referentially transparent - and we don't need to
+      reschedule the call with anything else and the manipuled block device can
+      not change (no side-effect are allowed). *)
+
+end


### PR DESCRIPTION
As discussed into our MirageOS meeting, I would like to add this new interface (and I will add a new type into `mirage/mirage`) to allow the manipulation of a block-device as a read-only filesystem. It fixes #53.

More precisely, this implementation is not a `mmap` implementation, it's just a referentially transparent `read` operation which can be outside `lwt` because we don't need to deal (with such view) with side-effects (like `write`).